### PR TITLE
deconstructor: check for frontier before length

### DIFF
--- a/lib/cfg/deconstructor.js
+++ b/lib/cfg/deconstructor.js
@@ -329,8 +329,10 @@ Deconstructor.prototype.visitBranch = function visitBranch(instr) {
     }
   };
 
+  var frontier = block.successors[0].frontier;
+
   // Queue frontier
-  if (block.successors[0].frontier.length)
+  if (frontier && frontier.length)
     this.queue.push(block.successors[0].frontier[0]);
 
   return res;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript AST to CFG converter",
   "main": "lib/cfg.js",
   "scripts": {
-    "test": "mocha --reporter spec test/*-test.js"
+    "test": "mocha --reporter spec test/*-test.js --globals match"
   },
   "repository": {
     "type": "git",

--- a/test/deconstructor-test.js
+++ b/test/deconstructor-test.js
@@ -1,20 +1,20 @@
 var assert = require('assert');
 var escodegen = require('escodegen');
-var ir = require('ssa-ir');
-var ssa = require('../');
+var ir = require('cfg-ir');
+var cfg = require('../');
 
 var fixtures = require('./fixtures');
 var strip = fixtures.strip;
 var equalLines = fixtures.equalLines;
 
-describe('SSA.js/Deconstructor', function() {
+describe('CFG.js/Deconstructor', function() {
   function test(name, input, expected, options) {
     it('should ' + name, function() {
       var repr = ir.parse(
           input.toString().replace(/^function.*{\/\*|\*\/}$/g, '')
       );
 
-      var str = escodegen.generate(ssa.deconstruct(repr, options));
+      var str = escodegen.generate(cfg.deconstruct(repr, options));
 
       var exp = expected.toString().replace(/^function.*{|}$/g, '');
       equalLines(strip(str), strip(exp));


### PR DESCRIPTION
This change also adds a mocha leak ignore when checking global scope, allowing all tests to pass by default, and removes legacy SSA.js names.
