### PR TITLE
Simplify reference handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ WIP
 * `loadProperty(obj, prop)`
 * `storeProperty(obj, prop, value)`
 * `deleteProperty(obj, prop)`
-* `loadGlobal(%prop)`
-* `storeGlobal(%prop, value)`
-* `deleteGlobal(%prop)`
 * `loadContext(%depth, %index)`
 * `storeContext(%depth, %index, value)`
 * `binary(%operator, left, right)`

--- a/lib/cfg/constructor.js
+++ b/lib/cfg/constructor.js
@@ -160,17 +160,8 @@ Constructor.prototype.visitAssignment = function visitAssignment(ast) {
 Constructor.prototype.visitProperty = function visitProperty(ast) {
   const slot = this.toSlot(ast);
 
-  let res;
-  if (slot.kind === 'named') {
-    res = this.pipeline.add('loadNamedProperty', slot.object)
-        .addLiteral(slot.name);
-  } else {
-    assert.equal(slot.kind, 'property');
-
-    res = this.pipeline.add('loadProperty', [ slot.object, slot.property ]);
-  }
-
-  return this.bind(res, ast);
+  assert.equal(slot.kind, 'property');
+  return this.bind(this.pipeline.add('loadProperty', [ slot.object, slot.property ]), ast);
 };
 
 Constructor.prototype.visitVarDecl = function visitVarDecl(ast) {
@@ -276,11 +267,9 @@ Constructor.prototype.toSlot = function toSlot(ast) {
   let current = ast;
   if (current.type === 'MemberExpression') {
     const obj = this.visit(current.object);
+    const prop = current.computed ? this.visit(current.property) : this.visitLiteral({ type: 'Literal', value: current.property.name });
 
-    if (!current.computed)
-      return Slot.createNamedProperty(obj, current.property.name);
-
-    return Slot.createProperty(obj, this.visit(current.property));
+    return Slot.createProperty(obj, prop);
   }
 
   assert.equal(current.type, 'Identifier');
@@ -314,9 +303,6 @@ Constructor.prototype.store = function store(slot, right, ast) {
     }
 
     res.addInput(right);
-  } else if (slot.kind === 'named') {
-    res = this.pipeline.add('storeNamedProperty', [ slot.object, right ]);
-    res.addLiteral(slot.name);
   } else {
     assert.equal(slot.kind, 'property');
 

--- a/lib/cfg/constructor.js
+++ b/lib/cfg/constructor.js
@@ -63,14 +63,12 @@ Constructor.prototype.visit = function visit(ast) {
     return this.visitStmt(ast);
   else if (ast.type === 'BlockStatement')
     return this.visitBlock(ast);
-  else if (ast.type === 'Identifier')
-    return this.visitIdentifier(ast);
+  else if (ast.type === 'Identifier' || ast.type === 'MemberExpression')
+    return this.visitReference(ast);
   else if (ast.type === 'Literal')
     return this.visitLiteral(ast);
   else if (ast.type === 'AssignmentExpression')
     return this.visitAssignment(ast);
-  else if (ast.type === 'MemberExpression')
-    return this.visitProperty(ast);
   else if (ast.type === 'VariableDeclaration')
     return this.visitVarDecl(ast);
   else if (ast.type === 'FunctionDeclaration')
@@ -112,16 +110,14 @@ Constructor.prototype.visitBlock = function visitBlock(ast) {
   return null;
 };
 
-Constructor.prototype.visitIdentifier = function visitIdentifier(ast) {
+Constructor.prototype.visitReference = function visitReference(ast) {
   const slot = this.toSlot(ast);
 
   let res;
   if (slot.kind === 'var') {
     const ref = slot.ref;
 
-    if (ref.resolved === null) {
-      res = this.pipeline.add('loadGlobal').addLiteral(ref.identifier.name);
-    } else if (ref.resolved.stack) {
+    if (ref.resolved.stack) {
       res = this.pipeline.add('ssa:load').addLiteral(this.rename(ref.resolved));
     } else if (ref.resolved.scope.type === 'function-expression-name') {
       let depth = -1;
@@ -136,6 +132,9 @@ Constructor.prototype.visitIdentifier = function visitIdentifier(ast) {
       throw new Error('Context loads not implemented yet');
     }
   } else {
+    assert.equal(slot.kind, 'property');
+
+    res = this.pipeline.add('loadProperty', [ slot.object, slot.property ]);
   }
 
   this.bind(res, ast);
@@ -155,13 +154,6 @@ Constructor.prototype.visitAssignment = function visitAssignment(ast) {
   }
 
   throw new Error('Not implemented');
-};
-
-Constructor.prototype.visitProperty = function visitProperty(ast) {
-  const slot = this.toSlot(ast);
-
-  assert.equal(slot.kind, 'property');
-  return this.bind(this.pipeline.add('loadProperty', [ slot.object, slot.property ]), ast);
 };
 
 Constructor.prototype.visitVarDecl = function visitVarDecl(ast) {
@@ -201,55 +193,61 @@ Constructor.prototype.enter = function enter(ast) {
   this.scope = next;
 
   let undef;
+  let global;
   let hole;
 
   // Initialize all scope variables
   for (let i = 0; i < next.variables.length; i++) {
     const v = next.variables[i];
 
-    if (v.scope.type === 'function') {
+    if (v.scope.type === 'function-expression-name') {
+      // Nothing to do, it is in the context
+    } else if (v.scope.type === 'global') {
+      const def = v.defs[0];
+
+      if (def.type !== 'FunctionName')
+        continue;
+
+      if (!global)
+        global = this.pipeline.add('global');
+
+      const node = def.node;
+      const name = this.bind(
+        this.pipeline.add('literal').addLiteral(node.id.name),
+        node.id
+      );
+      const slot = Slot.createProperty(global, name);
+      this.store(slot, this.declareFn(node), node);
+      // TODO(indutny): const/let can be declared only once
+    } else {
       let value;
 
-      if (v.name === 'arguments' && v.defs.length === 0) {
+      if (v.scope.type === 'function') {
+        if (v.name !== 'arguments' || v.defs.length !== 0)
+          continue;
+
         if (!v.scope.isArgumentsMaterialized())
           continue;
 
         value = this.pipeline.add('arguments');
+      } else if (v.stack) {
+        if (v.defs[0].kind === 'var') {
+          if (!undef)
+            undef = this.pipeline.add('literal').addLiteral('undefined');
+
+          value = undef;
+        } else {
+          // TODO(indutny): different holes for const/let ?
+          if (!hole)
+            hole = this.pipeline.add('oddball').addLiteral('hole');
+
+          value = hole;
+        }
       } else {
-        continue;
+        throw new Error('No context variables so far');
       }
 
       this.pipeline.add('ssa:store', value).addLiteral(this.rename(v));
-    } else if (v.scope.type === 'function-expression-name') {
-      // Nothing to do, it is in the context
-    } else if (v.scope.type === 'global') {
-      let value;
-
-      if (v.defs[0].type === 'FunctionName')
-        value = this.declareFn(v.defs[0].node);
-      else
-        continue;
-
-      this.pipeline.add('storeGlobal', value).addLiteral(v.name);
-      // TODO(indutny): const/let can be declared only once
-    } else if (v.stack) {
-      let value;
-      if (v.defs[0].kind === 'var') {
-        if (!undef)
-          undef = this.pipeline.add('literal').addLiteral('undefined');
-
-        value = undef;
-      } else {
-        // TODO(indutny): different holes for const/let ?
-        if (!hole)
-          hole = this.pipeline.add('oddball').addLiteral('hole');
-
-        value = hole;
-      }
-
-      this.pipeline.add('ssa:store', value).addLiteral(this.rename(v));
-    } else {
-      throw new Error('No context variables so far');
     }
   }
 };
@@ -267,7 +265,17 @@ Constructor.prototype.toSlot = function toSlot(ast) {
   let current = ast;
   if (current.type === 'MemberExpression') {
     const obj = this.visit(current.object);
-    const prop = current.computed ? this.visit(current.property) : this.visitLiteral({ type: 'Literal', value: current.property.name });
+    const propAST = current.property;
+    let prop;
+
+    if (current.computed) {
+      prop = this.visit(propAST);
+    } else {
+      prop = this.bind(
+        this.pipeline.add('literal').addLiteral(propAST.name),
+        propAST
+      );
+    }
 
     return Slot.createProperty(obj, prop);
   }
@@ -277,6 +285,17 @@ Constructor.prototype.toSlot = function toSlot(ast) {
   const ref = this.scope.resolve(current);
 
   assert(ref, 'Unknown reference');
+
+  if (ref.resolved === null) {
+    const obj = this.pipeline.add('global');
+    const prop = this.bind(
+      this.pipeline.add('literal').addLiteral(ref.identifier.name),
+      ref.identifier
+    );
+
+    return Slot.createProperty(obj, prop);
+  }
+
   return Slot.createVar(ref);
 };
 
@@ -293,9 +312,7 @@ Constructor.prototype.store = function store(slot, right, ast) {
   if (slot.kind === 'var') {
     const ref = slot.ref;
 
-    if (ref.resolved === null) {
-      res = this.pipeline.add('storeGlobal').addLiteral(ref.identifier.name);
-    } else if (ref.resolved.stack) {
+    if (ref.resolved.stack) {
       res = this.pipeline.add('ssa:store')
           .addLiteral(this.rename(ref.resolved));
     } else {

--- a/lib/cfg/constructor.js
+++ b/lib/cfg/constructor.js
@@ -262,41 +262,32 @@ Constructor.prototype.rename = function rename(v) {
 };
 
 Constructor.prototype.toSlot = function toSlot(ast) {
-  let current = ast;
-  if (current.type === 'MemberExpression') {
-    const obj = this.visit(current.object);
-    const propAST = current.property;
-    let prop;
+  let obj, propAST;
 
-    if (current.computed) {
-      prop = this.visit(propAST);
-    } else {
-      prop = this.bind(
-        this.pipeline.add('literal').addLiteral(propAST.name),
-        propAST
-      );
+  if (ast.type === 'MemberExpression') {
+    obj = this.visit(ast.object);
+    propAST = ast.property;
+
+    if (ast.computed) {
+      return Slot.createProperty(obj, this.visit(propAST));
+    }
+  } else {
+    assert.equal(ast.type, 'Identifier');
+
+    const ref = this.scope.resolve(ast);
+    assert(ref, 'Unknown reference');
+
+    if (ref.resolved !== null) {
+      return Slot.createVar(ref);
     }
 
-    return Slot.createProperty(obj, prop);
+    obj = this.pipeline.add('global');
+    propAST = ref.identifier;
   }
 
-  assert.equal(current.type, 'Identifier');
+  const prop = this.pipeline.add('literal').addLiteral(propAST.name);
 
-  const ref = this.scope.resolve(current);
-
-  assert(ref, 'Unknown reference');
-
-  if (ref.resolved === null) {
-    const obj = this.pipeline.add('global');
-    const prop = this.bind(
-      this.pipeline.add('literal').addLiteral(ref.identifier.name),
-      ref.identifier
-    );
-
-    return Slot.createProperty(obj, prop);
-  }
-
-  return Slot.createVar(ref);
+  return Slot.createProperty(obj, this.bind(prop, propAST));
 };
 
 Constructor.prototype.bind = function bind(node, ast) {

--- a/lib/cfg/slot.js
+++ b/lib/cfg/slot.js
@@ -15,17 +15,9 @@ Slot.createVar = function createVar(ref) {
   return res;
 };
 
-
 Slot.createProperty = function createProperty(object, property) {
   const res = new Slot('property');
   res.object = object;
   res.property = property;
-  return res;
-};
-
-Slot.createNamedProperty = function createNamedProperty(object, name) {
-  const res = new Slot('named');
-  res.object = object;
-  res.name = name;
   return res;
 };

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -71,7 +71,8 @@ describe('CFG.js/Constructor', () => {
       }, `pipeline {
         b0 {
           i0 = loadGlobal "a"
-          i1 = loadNamedProperty "b", i0
+          i1 = literal "b"
+          i2 = loadProperty i0, i1
         }
       }`);
     });
@@ -82,8 +83,9 @@ describe('CFG.js/Constructor', () => {
       }, `pipeline {
         b0 {
           i0 = loadGlobal "a"
-          i1 = literal 1
-          i2 = storeNamedProperty "b", i0, i1
+          i1 = literal "b"
+          i2 = literal 1
+          i3 = storeProperty i0, i1, i2
         }
       }`);
     });

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -47,7 +47,9 @@ describe('CFG.js/Constructor', () => {
         a;
       }, `pipeline {
         b0 {
-          i0 = loadGlobal "a"
+          i0 = global
+          i1 = literal "a"
+          i2 = loadProperty i0, i1
         }
       }`);
     });
@@ -57,8 +59,10 @@ describe('CFG.js/Constructor', () => {
         a = 1;
       }, `pipeline {
         b0 {
-          i0 = literal 1
-          i1 = storeGlobal "a", i0
+          i0 = global
+          i1 = literal "a"
+          i2 = literal 1
+          i3 = storeProperty i0, i1, i2
         }
       }`);
     });
@@ -70,9 +74,11 @@ describe('CFG.js/Constructor', () => {
         a.b;
       }, `pipeline {
         b0 {
-          i0 = loadGlobal "a"
-          i1 = literal "b"
+          i0 = global
+          i1 = literal "a"
           i2 = loadProperty i0, i1
+          i3 = literal "b"
+          i4 = loadProperty i2, i3
         }
       }`);
     });
@@ -82,10 +88,12 @@ describe('CFG.js/Constructor', () => {
         a.b = 1;
       }, `pipeline {
         b0 {
-          i0 = loadGlobal "a"
-          i1 = literal "b"
-          i2 = literal 1
-          i3 = storeProperty i0, i1, i2
+          i0 = global
+          i1 = literal "a"
+          i2 = loadProperty i0, i1
+          i3 = literal "b"
+          i4 = literal 1
+          i5 = storeProperty i2, i3, i4
         }
       }`);
     });
@@ -95,9 +103,11 @@ describe('CFG.js/Constructor', () => {
         a['b'];
       }, `pipeline {
         b0 {
-          i0 = loadGlobal "a"
-          i1 = literal "b"
+          i0 = global
+          i1 = literal "a"
           i2 = loadProperty i0, i1
+          i3 = literal "b"
+          i4 = loadProperty i2, i3
         }
       }`);
     });
@@ -107,10 +117,12 @@ describe('CFG.js/Constructor', () => {
         a['b'] = 1;
       }, `pipeline {
         b0 {
-          i0 = loadGlobal "a"
-          i1 = literal "b"
-          i2 = literal 1
-          i3 = storeProperty i0, i1, i2
+          i0 = global
+          i1 = literal "a"
+          i2 = loadProperty i0, i1
+          i3 = literal "b"
+          i4 = literal 1
+          i5 = storeProperty i2, i3, i4
         }
       }`);
     });
@@ -125,11 +137,17 @@ describe('CFG.js/Constructor', () => {
         a = 1;
       }, `pipeline {
         b0 {
-          i0 = literal 0
-          i1 = storeGlobal "a", i0
-          i2 = loadGlobal "a"
-          i3 = literal 1
-          i4 = storeGlobal "a", i3
+          i0 = global
+          i1 = literal "a"
+          i2 = literal 0
+          i3 = storeProperty i0, i1, i2
+          i4 = global
+          i5 = literal "a"
+          i6 = loadProperty i4, i5
+          i7 = global
+          i8 = literal "a"
+          i9 = literal 1
+          i10 = storeProperty i7, i8, i9
         }
       }`);
     });
@@ -144,8 +162,10 @@ describe('CFG.js/Constructor', () => {
         }
       }, `pipeline {
         b0 {
-          i0 = fn 1
-          i1 = storeGlobal "local", i0
+          i0 = global
+          i1 = literal "local"
+          i2 = fn 1
+          i3 = storeProperty i0, i1, i2
         }
       }
       1: pipeline {
@@ -233,14 +253,20 @@ describe('CFG.js/Constructor', () => {
         }
       }, `pipeline {
         b0 {
-          i0 = fn 1
-          i1 = storeGlobal "a", i0
-          i2 = loadGlobal "a"
+          i0 = global
+          i1 = literal "a"
+          i2 = fn 1
+          i3 = storeProperty i0, i1, i2
+          i4 = global
+          i5 = literal "a"
+          i6 = loadProperty i4, i5
         }
       }
       1: pipeline {
         b0 {
-          i0 = loadGlobal "a"
+          i0 = global
+          i1 = literal "a"
+          i2 = loadProperty i0, i1
         }
       }`);
     });
@@ -252,8 +278,10 @@ describe('CFG.js/Constructor', () => {
         }
       }, `pipeline {
         b0 {
-          i0 = fn 1
-          i1 = storeGlobal "b", i0
+          i0 = global
+          i1 = literal "b"
+          i2 = fn 1
+          i3 = storeProperty i0, i1, i2
         }
       }
       1: pipeline {
@@ -272,8 +300,10 @@ describe('CFG.js/Constructor', () => {
         }
       }, `pipeline {
         b0 {
-          i0 = fn 1
-          i1 = storeGlobal "b", i0
+          i0 = global
+          i1 = literal "b"
+          i2 = fn 1
+          i3 = storeProperty i0, i1, i2
         }
       }
       1: pipeline {


### PR DESCRIPTION
- Removes named property handlers

Those are unnecessary since can be simulated by combining `literal` and more generic computed property handlers.

- Removes global operations

Removes `load/store/deleteGlobal` in favor of `global` constant, `literal` and property operations. This increases size of generated IR, but reduces number of operations we need to care about on future stages (and multiple appearances of `global` itself can be reduced as any other constant).