### PR TITLE
Add maths support

### DIFF
--- a/lib/cfg/constructor.js
+++ b/lib/cfg/constructor.js
@@ -75,6 +75,10 @@ Constructor.prototype.visit = function visit(ast) {
     return this.visitFnDecl(ast);
   else if (ast.type === 'FunctionExpression')
     return this.visitFnExpr(ast);
+  else if (ast.type === 'UnaryExpression')
+    return this.visitUnary(ast);
+  else if (ast.type === 'BinaryExpression')
+    return this.visitBinary(ast);
   else
     assert(false, `Unknown AST node type: "${ast.type}"`);
 };
@@ -111,34 +115,7 @@ Constructor.prototype.visitBlock = function visitBlock(ast) {
 };
 
 Constructor.prototype.visitReference = function visitReference(ast) {
-  const slot = this.toSlot(ast);
-
-  let res;
-  if (slot.kind === 'var') {
-    const ref = slot.ref;
-
-    if (ref.resolved.stack) {
-      res = this.pipeline.add('ssa:load').addLiteral(this.rename(ref.resolved));
-    } else if (ref.resolved.scope.type === 'function-expression-name') {
-      let depth = -1;
-      for (let s = this.scope; s !== ref.resolved.scope; s = s.upper) {
-        if (s.type === 'function')
-          depth++;
-      }
-
-      res = this.pipeline.add('loadContext').addLiteral(depth);
-      res.addLiteral(CONTEXT_SLOT_SELF);
-    } else {
-      throw new Error('Context loads not implemented yet');
-    }
-  } else {
-    assert.equal(slot.kind, 'property');
-
-    res = this.pipeline.add('loadProperty', [ slot.object, slot.property ]);
-  }
-
-  this.bind(res, ast);
-  return res;
+  return this.load(this.toSlot(ast), ast);
 };
 
 Constructor.prototype.visitLiteral = function visitLiteral(ast) {
@@ -146,14 +123,27 @@ Constructor.prototype.visitLiteral = function visitLiteral(ast) {
 };
 
 Constructor.prototype.visitAssignment = function visitAssignment(ast) {
-  if (ast.operator === '=') {
-    const slot = this.toSlot(ast.left);
-    const right = this.visit(ast.right);
+  const slot = this.toSlot(ast.left);
 
-    return this.store(slot, right, ast);
+  let right;
+
+  if (ast.operator !== '=') {
+    assert.equal(ast.operator[ast.operator.length - 1], '=');
+
+    const initialValue = this.load(slot, ast.left);
+
+    const arg = this.visit(ast.right);
+
+    right =
+      this.pipeline.add('binary')
+      .addLiteral(ast.operator.slice(0, -1))
+      .addInput(initialValue)
+      .addInput(arg);
+  } else {
+    right = this.visit(ast.right);
   }
 
-  throw new Error('Not implemented');
+  return this.store(slot, right, ast);
 };
 
 Constructor.prototype.visitVarDecl = function visitVarDecl(ast) {
@@ -179,6 +169,30 @@ Constructor.prototype.visitFnDecl = function visitFnDecl(ast) {
 
 Constructor.prototype.visitFnExpr = function visitFnExpr(ast) {
   return this.declareFn(ast);
+};
+
+Constructor.prototype.visitUnary = function visitUnary(ast) {
+  const arg = this.visit(ast.argument);
+
+  const res =
+    this.pipeline.add('unary')
+    .addLiteral(ast.operator)
+    .addInput(arg);
+
+  return this.bind(res, ast);
+};
+
+Constructor.prototype.visitBinary = function visitBinary(ast) {
+  const left = this.visit(ast.left);
+  const right = this.visit(ast.right);
+
+  const res =
+    this.pipeline.add('binary')
+    .addLiteral(ast.operator)
+    .addInput(left)
+    .addInput(right);
+
+  return this.bind(res, ast);
 };
 
 //
@@ -296,6 +310,35 @@ Constructor.prototype.bind = function bind(node, ast) {
 
   node.data = ast;
   return node;
+};
+
+Constructor.prototype.load = function load(slot, ast) {
+  let res;
+  if (slot.kind === 'var') {
+    const ref = slot.ref;
+
+    if (ref.resolved.stack) {
+      res = this.pipeline.add('ssa:load').addLiteral(this.rename(ref.resolved));
+    } else if (ref.resolved.scope.type === 'function-expression-name') {
+      let depth = -1;
+      for (let s = this.scope; s !== ref.resolved.scope; s = s.upper) {
+        if (s.type === 'function')
+          depth++;
+      }
+
+      res = this.pipeline.add('loadContext').addLiteral(depth);
+      res.addLiteral(CONTEXT_SLOT_SELF);
+    } else {
+      throw new Error('Context loads not implemented yet');
+    }
+  } else {
+    assert.equal(slot.kind, 'property');
+
+    res = this.pipeline.add('loadProperty', [ slot.object, slot.property ]);
+  }
+
+  this.bind(res, ast);
+  return res;
 };
 
 Constructor.prototype.store = function store(slot, right, ast) {

--- a/lib/cfg/constructor.js
+++ b/lib/cfg/constructor.js
@@ -79,6 +79,8 @@ Constructor.prototype.visit = function visit(ast) {
     return this.visitUnary(ast);
   else if (ast.type === 'BinaryExpression')
     return this.visitBinary(ast);
+  else if (ast.type === 'UpdateExpression')
+    return this.visitUpdate(ast);
   else
     assert(false, `Unknown AST node type: "${ast.type}"`);
 };
@@ -193,6 +195,24 @@ Constructor.prototype.visitBinary = function visitBinary(ast) {
     .addInput(right);
 
   return this.bind(res, ast);
+};
+
+Constructor.prototype.visitUpdate = function visitUpdate(ast) {
+  const slot = this.toSlot(ast.argument);
+
+  const initialValue = this.load(slot, ast.argument);
+
+  const diff = this.pipeline.add('literal').addLiteral(1);
+
+  const updatedValue =
+    this.pipeline.add('binary')
+    .addLiteral(ast.operator === '++' ? '+' : '-')
+    .addInput(initialValue)
+    .addInput(diff);
+
+  const res = this.store(slot, updatedValue, ast.argument);
+
+  return ast.prefix ? res : initialValue;
 };
 
 //

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -379,5 +379,39 @@ describe('CFG.js/Constructor', () => {
         }
       }`);
     });
+
+    it('should support update operators', () => {
+      test(() => {
+        function f() {
+          var x = 1;
+          var y;
+          y = x++;
+          y = ++x;
+        }
+      }, `pipeline {
+        b0 {
+          i0 = global
+          i1 = literal "f"
+          i2 = fn 1
+          i3 = storeProperty i0, i1, i2
+        }
+      }
+      1: pipeline {
+        b0 {
+          i0 = literal 1
+          i1 = ssa:store "0/x", i0
+          i2 = ssa:load "0/x"
+          i3 = literal 1
+          i4 = binary "+", i2, i3
+          i5 = ssa:store "0/x", i4
+          i6 = ssa:store "1/y", i2
+          i7 = ssa:load "0/x"
+          i8 = literal 1
+          i9 = binary "+", i7, i8
+          i10 = ssa:store "0/x", i9
+          i11 = ssa:store "1/y", i10
+        }
+      }`);
+    });
   });
 });

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -319,4 +319,65 @@ describe('CFG.js/Constructor', () => {
       }`);
     });
   });
+
+  describe('math', () => {
+    it('should support unary operations', () => {
+      test(() => {
+        +1;
+      }, `pipeline {
+        b0 {
+          i0 = literal 1
+          i1 = unary "+", i0
+        }
+      }`);
+    });
+
+    it('should support binary operations', () => {
+      test(() => {
+        2 + 2 == 4;
+      }, `pipeline {
+        b0 {
+          i0 = literal 2
+          i1 = literal 2
+          i2 = binary "+", i0, i1
+          i3 = literal 4
+          i4 = binary "==", i2, i3
+        }
+      }`);
+    });
+
+    it('should execute operations according to precedence', () => {
+      test(() => {
+        var t = 1 - 2 * 3;
+      }, `pipeline {
+        b0 {
+          i0 = global
+          i1 = literal "t"
+          i2 = literal 1
+          i3 = literal 2
+          i4 = literal 3
+          i5 = binary "*", i3, i4
+          i6 = binary "-", i2, i5
+          i7 = storeProperty i0, i1, i6
+        }
+      }`);
+    });
+
+    it('should support combined assignment/binary operations', () => {
+      test(() => {
+        obj.prop += 10;
+      }, `pipeline {
+        b0 {
+          i0 = global
+          i1 = literal "obj"
+          i2 = loadProperty i0, i1
+          i3 = literal "prop"
+          i4 = loadProperty i2, i3
+          i5 = literal 10
+          i6 = binary "+", i4, i5
+          i7 = storeProperty i2, i3, i6
+        }
+      }`);
+    });
+  });
 });


### PR DESCRIPTION
Adds support for unary, binary expressions and complex assignment operations.

Currently depends on #4 to be merged first (only commit https://github.com/js-js/cfg.js/commit/50c20fd2afe5b51e993a44eacea82f732629135f is relevant).